### PR TITLE
Fix dead /archive/ link in post footer

### DIFF
--- a/dash-o-pepper/index.html
+++ b/dash-o-pepper/index.html
@@ -212,7 +212,7 @@ fatal: repository 'https://github.com/-/test.git/' not found</code></pre>
       <p>Also, my app is a work in progress but it's open source, feel free to play on it if you want, the code is at <u>https://github.com/this-fifo/stella</u></p>
     </main>
     <footer>
-      <p><a href="/archive/">← Back to the archive</a></p>
+      <p><a href="/">← Back home</a></p>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
The Dash O'Pepper footer still linked `← Back to the archive` → `/archive/`, which 404s since the archive was retired. Now `← Back home` → `/`.